### PR TITLE
suspense delay 추가 및 default 이미지 수정

### DIFF
--- a/frontend/src/components/common/AsyncBoundary.tsx
+++ b/frontend/src/components/common/AsyncBoundary.tsx
@@ -28,7 +28,7 @@ export const AsyncBoundary = forwardRef<any, AsyncBoundaryProps>(
           setShowPendingFallback(true);
         }, delay);
 
-        return () => clearTimeout(timer); // Cleanup timer on unmount
+        return () => clearTimeout(timer);
       }
     }, [delay]);
 

--- a/frontend/src/components/common/AsyncBoundary.tsx
+++ b/frontend/src/components/common/AsyncBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Suspense } from 'react';
 
@@ -6,11 +6,15 @@ interface AsyncBoundaryProps {
   pendingFallback: React.ReactNode;
   rejectedFallback: (error: Error) => React.ReactNode;
   children: React.ReactNode;
+  delay?: number;
 }
 
+const DEFAULT_DELAY = 1000;
+
 export const AsyncBoundary = forwardRef<any, AsyncBoundaryProps>(
-  ({ pendingFallback, rejectedFallback, children }, ref) => {
+  ({ pendingFallback, rejectedFallback, children, delay = DEFAULT_DELAY }, ref) => {
     // error 추후에 작업예정
+    const [showPendingFallback, setShowPendingFallback] = useState(delay === DEFAULT_DELAY);
     const [, setError] = useState<Error | null>(null);
 
     // Use `useImperativeHandle` to expose a `reset` method to parent component
@@ -18,13 +22,30 @@ export const AsyncBoundary = forwardRef<any, AsyncBoundaryProps>(
       reset: () => setError(null)
     }));
 
+    useEffect(() => {
+      if (delay > DEFAULT_DELAY) {
+        const timer = setTimeout(() => {
+          setShowPendingFallback(true);
+        }, delay);
+
+        return () => clearTimeout(timer); // Cleanup timer on unmount
+      }
+    }, [delay]);
+
     const handleError = (error: Error) => {
       setError(error);
     };
 
     return (
-      <ErrorBoundary FallbackComponent={({ error }) => rejectedFallback(error)} onError={handleError}>
-        <Suspense fallback={pendingFallback}>{children}</Suspense>
+      <ErrorBoundary
+        FallbackComponent={({ error }) => rejectedFallback(error)}
+        onError={handleError}
+      >
+        {showPendingFallback ? (
+          <Suspense fallback={pendingFallback}>{children}</Suspense>
+        ) : (
+          <>{children}</>
+        )}
       </ErrorBoundary>
     );
   }

--- a/frontend/src/components/main/LiveVideoCard.tsx
+++ b/frontend/src/components/main/LiveVideoCard.tsx
@@ -26,11 +26,17 @@ const LiveVideoCard = ({ videoData }: LiveVideoCardProps) => {
     liveTitle,
     streamUrl
   } = videoData;
-
+  console.log("videoData", videoData);
   const { isHovered, isVideoLoaded, videoRef, handleMouseEnter, handleMouseLeave } = useVideoPreview(streamUrl);
 
   const handleLiveClick = () => {
     navigate(`/live/${liveId}`);
+  };
+  console.log("liveImageUrl", liveImageUrl);
+  console.log("defaultThumbnailImageUrl", defaultThumbnailImageUrl);
+
+  const handleError = (event: React.SyntheticEvent<HTMLImageElement>) => {
+    event.currentTarget.src = defaultThumbnailImageUrl
   };
 
   return (
@@ -40,7 +46,7 @@ const LiveVideoCard = ({ videoData }: LiveVideoCardProps) => {
           <video ref={videoRef} muted playsInline preload="none" />
         </VideoBox>
         <VideoCardThumbnail $isVideoVisible={isHovered && isVideoLoaded}>
-          <VideoCardImage src={liveImageUrl ?? defaultThumbnailImageUrl} />
+          <VideoCardImage src={liveImageUrl ?? defaultThumbnailImageUrl} onError={handleError}/>
         </VideoCardThumbnail>
         <VideoCardDescription>
           <LiveBadge />


### PR DESCRIPTION
## 🚀 Issue Number
- #4 

## 주요 작업
- 1초 이상 작업에 대해서만 suspense를 사용하도록 작업
- 서버에서 잘못된 이미지를 주는 경우 default 이미지로 대체하도록 작업


## 고민과 해결 과정
사용자 경험 개선을 위해 무분별한 suspense 막기

세계적인 UX 리서치 그룹 닐슨 노먼에서 진행한 발표 내용에서 사용자 경험을 위해 준수해야 할 사항들 중 한가지인 **`약 1.0초 이상 걸리는 작업에는 progress indicator를 사용하십시오`** 라는 준수사항이 있었음

- DEFAULT_DELAY를 `1초`로 도입
```
const DEFAULT_DELAY = 1000;

export const AsyncBoundary = forwardRef<any, AsyncBoundaryProps>(
  ({ pendingFallback, rejectedFallback, children, delay = DEFAULT_DELAY }, ref) => {
    // error 추후에 작업예정
    const [showPendingFallback, setShowPendingFallback] = useState(delay === DEFAULT_DELAY);
    const [, setError] = useState<Error | null>(null);

    useImperativeHandle(ref, () => ({
      reset: () => setError(null)
    }));

    useEffect(() => {
      if (delay > DEFAULT_DELAY) {
        const timer = setTimeout(() => {
          setShowPendingFallback(true);
        }, delay);

        return () => clearTimeout(timer);
      }
    }, [delay]);

    const handleError = (error: Error) => {
      setError(error);
    };

    return (
      <ErrorBoundary
        FallbackComponent={({ error }) => rejectedFallback(error)}
        onError={handleError}
      >
        {showPendingFallback ? (
          <Suspense fallback={pendingFallback}>{children}</Suspense>
        ) : (
          <>{children}</>
        )}
      </ErrorBoundary>
    );
  }
);
```
## 📸 Screenshots


## 🔜 추가 내용 (선택)
